### PR TITLE
Add Sphere Geometry, expand C++ API, add grabber objects, change asg transfrom application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+asg/docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build/*
-asg/docs/*
+asg/docs/doxygen*

--- a/asg/asg.cpp
+++ b/asg/asg.cpp
@@ -2793,13 +2793,25 @@ static void visitANARIWorld(ASGVisitor self, ASGObject obj, void* userData) {
                 asg::Mat3f B{{trans->matrix[0],trans->matrix[1],trans->matrix[2]},
                              {trans->matrix[3],trans->matrix[4],trans->matrix[5]},
                              {trans->matrix[6],trans->matrix[7],trans->matrix[8]}};
-                asg::Mat3f C = A * B;
-                anari->trans.col0 = C.col0;
-                anari->trans.col1 = C.col1;
-                anari->trans.col2 = C.col2;
-                anari->trans.col3 += asg::Vec3f{trans->matrix[ 9],
-                                                trans->matrix[10],
-                                                trans->matrix[11]};
+
+                asg::Mat4f currentTrans{{prevTrans.col0.x, prevTrans.col0.y, prevTrans.col0.z, 0},
+                                        {prevTrans.col1.x, prevTrans.col1.y, prevTrans.col1.z, 0},
+                                        {prevTrans.col2.x, prevTrans.col2.y, prevTrans.col2.z, 0},
+                                        {prevTrans.col3.x, prevTrans.col3.y, prevTrans.col3.z, 1}};
+                asg::Mat4f currentRot{{trans->matrix[0], trans->matrix[1], trans->matrix[2], 0},
+                                      {trans->matrix[3], trans->matrix[4], trans->matrix[5], 0},
+                                      {trans->matrix[6], trans->matrix[7], trans->matrix[8], 0},
+                                      {0, 0, 0, 1}};
+                asg::Mat4f currentTranslation{{1, 0, 0, 0},
+                                              {0, 1, 0, 0},
+                                              {0, 0, 1, 0},
+                                              {trans->matrix[9], trans->matrix[10], trans->matrix[11], 1}};
+                asg::Mat4f res = currentTrans * currentTranslation * currentRot;
+
+                anari->trans.col0 = {res.col0.x, res.col0.y, res.col0.z};
+                anari->trans.col1 = {res.col1.x, res.col1.y, res.col1.z};
+                anari->trans.col2 = {res.col2.x, res.col2.y, res.col2.z};
+                anari->trans.col3 = {res.col3.x, res.col3.y, res.col3.z};
 
                 asgVisitorApply(self,obj);
 

--- a/asg/asg.cpp
+++ b/asg/asg.cpp
@@ -437,13 +437,14 @@ ASGError_t asgObjectGetChild(ASGObject obj, int childID, ASGObject* child)
     return ASG_ERROR_NO_ERROR;
 }
 
-ASGError_t asgObjectGetChildren(ASGObject obj, ASGObject* children, int* numChildren)
+ASGError_t asgObjectGetChildren(ASGObject obj, ASGObject** children, int* numChildren)
 {
     *numChildren = (int)obj->children.size();
     if (children == NULL) {
         return ASG_ERROR_NO_ERROR;
     } else {
-        std::memcpy(children,obj->children.data(),obj->children.size()*sizeof(ASGObject));
+
+        std::memcpy(*children,obj->children.data(),obj->children.size()*sizeof(ASGObject));
         return ASG_ERROR_NO_ERROR;
     }
 }

--- a/asg/asg.h
+++ b/asg/asg.h
@@ -215,7 +215,7 @@ ASGAPI ASGError_t asgObjectGetName(ASGObject obj, const char** name);
 ASGAPI ASGError_t asgObjectAddChild(ASGObject obj, ASGObject child);
 ASGAPI ASGError_t asgObjectSetChild(ASGObject obj, int childID, ASGObject child);
 ASGAPI ASGError_t asgObjectGetChild(ASGObject obj, int childID, ASGObject* child);
-ASGAPI ASGError_t asgObjectGetChildren(ASGObject obj, ASGObject* children,
+ASGAPI ASGError_t asgObjectGetChildren(ASGObject obj, ASGObject** children,
                                        int* numChildren);
 ASGAPI ASGError_t asgObjectRemoveChild(ASGObject obj, ASGObject child);
 ASGAPI ASGError_t asgObjectRemoveChildAt(ASGObject obj, int childID);

--- a/asg/asg.hpp
+++ b/asg/asg.hpp
@@ -55,6 +55,12 @@ namespace asg {
             void addChild(const std::shared_ptr<T>& child);
 
             std::shared_ptr<Object> getChild(int childID);
+
+           inline int getChildren();
+            inline const char* getName();
+            inline void setName(const char* name);
+            template <typename T>
+            void removeChild(const std::shared_ptr<T>& child);
         };
 
         class Geometry : public Object
@@ -84,7 +90,23 @@ namespace asg {
             operator ASGTriangleGeometry();
         };
 
-        class SphereGeometry;
+        class SphereGeometry : public Geometry
+        {
+            SphereGeometry(ASGGeometry obj);
+        public:
+            static std::shared_ptr<SphereGeometry> create(float* vertices, float* radii,
+                                                            float* vertexColors,
+                                                            uint32_t numVertices,
+                                                            uint32_t* indices,
+                                                            uint32_t numIndices,
+                                                            float defaultRadius,
+                                                            FreeFunc freeVertices,
+                                                            FreeFunc freeRadii,
+                                                            FreeFunc freeColors,
+                                                            FreeFunc freeIndices);
+
+            operator ASGSphereGeometry();
+        };
 
         class CylinderGeometry : public Geometry
         {
@@ -140,10 +162,20 @@ namespace asg {
             void translate(float x, float y, float z);
 
             void translate(float xyz[3]);
+            void rotate( float axis[3], float angleInRadians);
+            float* getMatrix(float matrix[12]);
 
         };
 
-        class Select;
+        class Select : public Object
+        {
+            Select(ASGSelect obj);
+        public:
+            static std::shared_ptr<Select> create(ASGBool_t defaultVisibility);
+            operator ASGSelect();
+            void getChildVisible(int childID, ASGBool_t visible);
+            void setChildVisible(int childID, ASGBool_t visible);
+        };;
         class Camera;
     } // detail
 
@@ -201,6 +233,22 @@ namespace asg {
                                                 freeColors,freeCaps,freeIndices);
     }
 
+    inline SphereGeometry newSphereGeometry(float* vertices, float* radii,
+                                                float* vertexColors,
+                                                uint32_t numVertices, uint32_t* indices,
+                                                uint32_t numIndices,
+                                                float defaultRadius = 1.f,
+                                                FreeFunc freeVertices = nullptr,
+                                                FreeFunc freeRadii = nullptr,
+                                                FreeFunc freeColors = nullptr,
+                                                FreeFunc freeIndices = nullptr)
+    {
+        return detail::SphereGeometry::create(vertices,radii,vertexColors,
+                                                numVertices,indices,numIndices,
+                                                defaultRadius,freeVertices,freeRadii,
+                                                freeColors,freeIndices);
+    }
+
     inline Material newMaterial(const char* materialType)
     {
         return detail::Material::create(materialType);
@@ -220,6 +268,10 @@ namespace asg {
                                   MatrixFormat format = ASG_MATRIX_FORMAT_COL_MAJOR)
     {
         return detail::Transform::create(initialMatrix,format);
+    }
+    inline Select newSelect(ASGBool_t defaultVisibility)
+    {
+        return detail::Select::create(defaultVisibility);
     }
 
 } // ::asg

--- a/asg/detail/asg.inl
+++ b/asg/detail/asg.inl
@@ -67,6 +67,33 @@ namespace asg {
             detail::errorFunc(asgObjectGetChild(handle,childID,&child));
             return std::shared_ptr<Object>(new Object(child));
         }
+        inline int Object::getChildren()
+        {
+
+            int numChildren;
+            detail::errorFunc(asgObjectGetChildren(handle,nullptr, &numChildren));
+           //  ASGObject* children = (ASGObject*)malloc(sizeof(ASGObject) * numChildren);
+
+            //detail::errorFunc(asgObjectGetChildren(handle,&children, &numChildren));
+
+
+            //return std::shared_ptr<Object*>(new Object*(reinterpret_cast<Object*>(children)));
+            return numChildren;
+        }
+        template <typename T>
+        inline void Object::removeChild(const std::shared_ptr<T>& child)
+        {
+            detail::errorFunc(asgObjectRemoveChild(handle,child.get()->handle));
+        }
+        inline void Object::setName(const char* name)
+        {
+            detail::errorFunc(asgObjectSetName(handle,name));
+        }
+        inline const char* Object::getName(){
+             const char* name;
+             detail::errorFunc(asgObjectGetName(handle,&name));
+             return name;
+        }
 
 
 
@@ -146,6 +173,33 @@ namespace asg {
                                        freeRadii,freeColors,freeCaps,freeIndices)));
         }
 
+        // ==========================================================
+        // SphereGeometry
+        // ==========================================================
+
+        SphereGeometry::SphereGeometry(ASGGeometry obj)
+            : Geometry(obj)
+        {
+        }
+
+        std::shared_ptr<SphereGeometry> SphereGeometry::create(float* vertices,
+                                                                   float* radii,
+                                                                   float* vertexColors,
+                                                                   uint32_t numVertices,
+                                                                   uint32_t* indices,
+                                                                   uint32_t numIndices,
+                                                                   float defaultRadius,
+                                                                   FreeFunc freeVertices,
+                                                                   FreeFunc freeRadii,
+                                                                   FreeFunc freeColors,
+                                                                   FreeFunc freeIndices)
+        {
+            return std::shared_ptr<SphereGeometry>(new SphereGeometry(
+                asgNewSphereGeometry(vertices,radii,vertexColors,numVertices,
+                                       indices,numIndices,defaultRadius,freeVertices,
+                                       freeRadii,freeColors,freeIndices)));
+        }
+
 
         // ==========================================================
         // Material
@@ -220,6 +274,38 @@ namespace asg {
         void Transform::translate(float xyz[3])
         {
             detail::errorFunc(asgTransformTranslate(handle,xyz));
+        }
+
+        void Transform::rotate( float axis[3],
+                                     float angleInRadians)
+        {
+
+            detail::errorFunc(asgTransformRotate(handle,axis,angleInRadians));
+        }
+        float* Transform::getMatrix(float matrix[12]){
+            detail::errorFunc(asgTransformGetMatrix(handle, matrix));
+            return matrix;
+        }
+        // ==========================================================
+        // Select
+        // ==========================================================
+        Select::Select(ASGSelect obj)
+            : Object(obj)
+        {
+        }
+        Select::operator ASGSelect()
+        {
+            return (ASGSelect)handle;
+        }
+        std::shared_ptr<Select> Select::create(ASGBool_t defaultVisibility)
+        {
+            return std::shared_ptr<Select>(new Select(asgNewSelect(defaultVisibility)));
+        }
+        void Select::getChildVisible( int childID, ASGBool_t visible){
+            detail::errorFunc(asgSelectGetChildVisible(handle,childID,&visible));
+        }
+        void Select::setChildVisible( int childID, ASGBool_t visible){
+            detail::errorFunc(asgSelectSetChildVisible(handle,childID,visible));
         }
     } // detail
 } // ::asg

--- a/asg/linalg.hpp
+++ b/asg/linalg.hpp
@@ -741,6 +741,32 @@ namespace asg
         out << '(' << m.col0 << ',' << m.col1 << ',' << m.col2 << ',' << m.col3 << ')';
         return out;
     }
+    //Mat4f
+     ASG_FUNC inline Mat4f operator*(Mat4f const& a, Mat4f const& b)
+    {
+        return Mat4f{
+            { a.col0.x*b.col0.x + a.col1.x*b.col0.y + a.col2.x*b.col0.z + a.col3.x*b.col0.w,
+              a.col0.y*b.col0.x + a.col1.y*b.col0.y + a.col2.y*b.col0.z + a.col3.y*b.col0.w,
+              a.col0.z*b.col0.x + a.col1.z*b.col0.y + a.col2.z*b.col0.z + a.col3.z*b.col0.w,
+              a.col0.w*b.col0.x + a.col1.w*b.col0.y + a.col2.w*b.col0.z + a.col3.w*b.col0.w
+              },
+            { a.col0.x*b.col1.x + a.col1.x*b.col1.y + a.col2.x*b.col1.z + a.col3.x*b.col1.w,
+              a.col0.y*b.col1.x + a.col1.y*b.col1.y + a.col2.y*b.col1.z + a.col3.y*b.col1.w,
+              a.col0.z*b.col1.x + a.col1.z*b.col1.y + a.col2.z*b.col1.z + a.col3.z*b.col1.w,
+              a.col0.w*b.col1.x + a.col1.w*b.col1.y + a.col2.w*b.col1.z + a.col3.w*b.col1.w
+              },
+            { a.col0.x*b.col2.x + a.col1.x*b.col2.y + a.col2.x*b.col2.z + a.col3.x*b.col2.w,
+              a.col0.y*b.col2.x + a.col1.y*b.col2.y + a.col2.y*b.col2.z + a.col3.y*b.col2.w,
+              a.col0.z*b.col2.x + a.col1.z*b.col2.y + a.col2.z*b.col2.z  + a.col3.z*b.col2.w,
+              a.col0.w*b.col2.x + a.col1.w*b.col2.y + a.col2.w*b.col2.z  + a.col3.w*b.col2.w,
+              },
+            { a.col0.x*b.col3.x + a.col1.x*b.col3.y + a.col2.x*b.col3.z + a.col3.x*b.col3.w,
+              a.col0.y*b.col3.x + a.col1.y*b.col3.y + a.col2.y*b.col3.z + a.col3.y*b.col3.w,
+              a.col0.z*b.col3.x + a.col1.z*b.col3.y + a.col2.z*b.col3.z  + a.col3.z*b.col3.w,
+              a.col0.w*b.col3.x + a.col1.w*b.col3.y + a.col2.w*b.col3.z  + a.col3.w*b.col3.w,
+              }
+        };
+    }
 
 } // asg
 

--- a/generic_device/CMakeLists.txt
+++ b/generic_device/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PROJECT_NAME}
     backend.cpp
     camera.cpp
     cylindergeom.cpp
+    spheregeom.cpp
     device.cpp
     frame.cpp
     geometry.cpp

--- a/generic_device/backend.hpp
+++ b/generic_device/backend.hpp
@@ -3,6 +3,7 @@
 #include "ao.hpp"
 #include "camera.hpp"
 #include "cylindergeom.hpp"
+#include "spheregeom.hpp"
 #include "frame.hpp"
 #include "group.hpp"
 #include "instance.hpp"
@@ -39,6 +40,8 @@ namespace generic {
         void commit(generic::Frame& frame);
 
         void commit(generic::TriangleGeom& geom);
+
+        void commit(generic::SphereGeom& geom);
 
         void commit(generic::CylinderGeom& geom);
 

--- a/generic_device/geometry.cpp
+++ b/generic_device/geometry.cpp
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <type_traits>
 #include "cylindergeom.hpp"
+#include "spheregeom.hpp"
 #include "geometry.hpp"
 #include "logging.hpp"
 #include "trianglegeom.hpp"
@@ -56,6 +57,8 @@ namespace generic {
             return std::make_unique<TriangleGeom>();
         else if (strncmp(subtype,"cylinder",8)==0)
             return std::make_unique<CylinderGeom>();
+        else if (strncmp(subtype,"sphere",5)==0)
+            return std::make_unique<SphereGeom>();
         else {
             LOG(logging::Level::Error) << "Geometry subtype unavailable: " << subtype;
             return std::make_unique<Geometry>();

--- a/generic_device/spheregeom.cpp
+++ b/generic_device/spheregeom.cpp
@@ -1,0 +1,91 @@
+#include <string.h>
+#include "backend.hpp"
+#include "spheregeom.hpp"
+#include "logging.hpp"
+
+namespace generic {
+
+    SphereGeom::SphereGeom()
+    {
+    }
+
+    SphereGeom::~SphereGeom()
+    {
+    }
+
+    void SphereGeom::commit()
+    {
+        if (vertex_position == nullptr)
+            LOG(logging::Level::Error) << "Sphere error: vertex.position not set but "
+                << "is a required parameter";
+        else
+            backend::commit(*this);
+    }
+
+    void SphereGeom::release()
+    {
+    }
+
+    void SphereGeom::retain()
+    {
+    }
+
+    void SphereGeom::setParameter(const char* name,
+                                    ANARIDataType type,
+                                    const void* mem)
+    {
+        if (strncmp(name,"vertex.position",15)==0 && type==ANARI_ARRAY1D) {
+            vertex_position = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.color",12)==0 && type==ANARI_ARRAY1D) {
+            vertex_color = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.attribute0",17)==0 && type==ANARI_ARRAY1D) {
+            vertex_attribute0 = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.attribute1",17)==0 && type==ANARI_ARRAY1D) {
+            vertex_attribute1 = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.attribute2",17)==0 && type==ANARI_ARRAY1D) {
+            vertex_attribute2 = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.attribute3",17)==0 && type==ANARI_ARRAY1D) {
+            vertex_attribute3 = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"primitive.index",15)==0 && type==ANARI_ARRAY1D) {
+            primitive_index = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"primitive.radius",16)==0 && type==ANARI_ARRAY1D) {
+            primitive_radius = *(ANARIArray1D*)mem; // TODO: reference count
+        } else if (strncmp(name,"vertex.radius",13)==0 && type==ANARI_ARRAY1D) {
+            vertex_radius = *(ANARIArray1D*)mem; // TODO: reference count
+        } 
+        else if (strncmp(name,"radius",6)==0 && type==ANARI_FLOAT32) {
+            memcpy(&radius,mem,sizeof(radius));
+        } else {
+            LOG(logging::Level::Warning) << "Sphere: Unsupported parameter "
+                << "/ parameter type: " << name << " / " << type;
+        }
+    }
+
+    void SphereGeom::unsetParameter(const char* name)
+    {
+        if (strncmp(name,"vertex.position",15)==0) {
+            vertex_position = nullptr;
+        } else if (strncmp(name,"vertex.color",12)==0) {
+            vertex_color = nullptr;
+        } else if (strncmp(name,"vertex.attribute0",17)==0) {
+            vertex_attribute0 = nullptr;
+        } else if (strncmp(name,"vertex.attribute1",17)==0) {
+            vertex_attribute1 = nullptr;
+        } else if (strncmp(name,"vertex.attribute2",17)==0) {
+            vertex_attribute2 = nullptr;
+        } else if (strncmp(name,"vertex.attribute3",17)==0) {
+            vertex_attribute3 = nullptr;
+        } else if (strncmp(name,"primitive.index",15)==0) {
+            primitive_index = nullptr;
+        } else if (strncmp(name,"primitive.radius",16)==0) {
+            primitive_radius = nullptr;
+        } else if (strncmp(name,"radius",6)==0) {
+            radius = 1.f;
+        } else {
+            LOG(logging::Level::Warning) << "Sphere: Unsupported parameter " << name;
+        }
+    }
+
+} // generic
+
+

--- a/generic_device/spheregeom.hpp
+++ b/generic_device/spheregeom.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "geometry.hpp"
+
+namespace generic {
+
+    class SphereGeom : public Geometry
+    {
+    public:
+        SphereGeom();
+       ~SphereGeom();
+
+        void commit();
+
+        void release();
+
+        void retain();
+
+        void setParameter(const char* name,
+                          ANARIDataType type,
+                          const void* mem);
+
+        void unsetParameter(const char* name);
+
+        ANARIArray1D vertex_position = nullptr;
+        ANARIArray1D vertex_radius = nullptr;
+        ANARIArray1D vertex_color = nullptr;
+        ANARIArray1D vertex_attribute0 = nullptr;
+        ANARIArray1D vertex_attribute1 = nullptr;
+        ANARIArray1D vertex_attribute2 = nullptr;
+        ANARIArray1D vertex_attribute3 = nullptr;
+        ANARIArray1D primitive_index = nullptr;
+        ANARIArray1D primitive_radius = nullptr;
+        float radius = 1.f;
+       
+    };
+
+} // generic
+
+

--- a/scenes.h
+++ b/scenes.h
@@ -76,6 +76,10 @@ struct Scene
     {
         return false;
     }
+     virtual bool handleKeyPress(visionaray::key_event const&)
+    {
+        return false;
+    }
 
     virtual bool needFrameReset()
     {
@@ -292,6 +296,151 @@ struct SphereTest : Scene
         return bbox;
     }
 };
+struct TransformTest :Scene
+{
+        TransformTest(ANARIDevice dev, ANARIWorld wrld, const char* fileName = NULL)
+        : Scene(dev,wrld)
+        {
+            root = asgNewObject();
+            static float vertex[] = {-1.f,-1.f,-1.f,
+                                  1.f,-1.f,-1.f,
+                                  1.f, 1.f,-1.f,
+                                 -1.f, 1.f,-1.f,
+                                  1.f,-1.f, 1.f,
+                                 -1.f,-1.f, 1.f,
+                                 -1.f, 1.f, 1.f,
+                                  1.f, 1.f, 1.f};
+
+            static uint32_t index[] = {0,1,2, 0,2,3, 4,5,6, 4,6,7,
+                                   1,4,7, 1,7,2, 5,0,3, 5,3,6,
+                                   5,4,1, 5,1,0, 3,2,7, 3,7,6};
+            float* cylVertex = new float[6] { 0.f,-1/2.f,0.f,
+                                          0.f,1/2.f,0.f };
+            float* cylRadius = new float[1] { 2};
+            uint8_t* cylCap = new uint8_t[1] { 1 };
+            ASGCylinderGeometry cyl = asgNewCylinderGeometry(
+                    cylVertex,cylRadius,nullptr,cylCap,2,nullptr,0);
+
+            ASGTriangleGeometry boxGeom = asgNewTriangleGeometry(vertex,NULL,NULL,8,
+                                                             index,12,NULL,NULL,NULL,
+                                                             NULL);
+
+            ASGMaterial mat1 = asgNewMaterial("");
+            ASGMaterial mat2 = asgNewMaterial("");
+            ASGMaterial mat3 = asgNewMaterial("");
+            float red[3] = {1.f,0.f,0.f};
+            float green[3] = {0.f,1.f,0.f};
+            float blue[3] = {0.f,0.f,1.f};
+            ASG_SAFE_CALL(asgMakeMatte(&mat1,red,NULL));
+            ASG_SAFE_CALL(asgMakeMatte(&mat2,green,NULL));
+            ASG_SAFE_CALL(asgMakeMatte(&mat3,blue,NULL));
+            ASGSurface surf_red = asgNewSurface(cyl,mat1);
+            ASGSurface surf_green = asgNewSurface(cyl,mat2);
+            ASGSurface surf_blue = asgNewSurface(cyl,mat3);
+
+            ASGTransform rot = makeRotation(1,M_PI/4.f);
+            ASGTransform trans = makeTransform(0,0,2,0,0);
+            ASGTransform trans_rot = makeTransform(1,M_PI/4.f,2,0,0);
+
+          //  ASG_SAFE_CALL(asgObjectAddChild(rot,surf_red));
+
+           ASGObject object = asgNewObject();
+           ASG_SAFE_CALL(asgObjectAddChild(trans,rot));
+
+
+
+            ASG_SAFE_CALL(asgObjectAddChild(root,trans));
+
+
+
+
+
+
+
+            ASGTransform trans2 = makeTransform(0,0,0,2,0);
+            ASGTransform rot2 = makeTransform(1,M_PI/4.f,2.f,0.f,0.f);
+            ASGObject object2 = asgNewObject();
+            ASG_SAFE_CALL(asgObjectAddChild(rot2,surf_blue));
+            ASG_SAFE_CALL(asgObjectAddChild(object2,rot2));
+            ASGObject obj;
+            ASG_SAFE_CALL(asgObjectGetChild(root,0,&obj));
+            ASG_SAFE_CALL(asgObjectAddChild(obj,object2));
+
+            ASGTransform new_trans = makeTransform(1,M_PI/4.f,2,0,0);
+             ASGTransform new_trans_rot = makeTransform(1,M_PI/4.f,2,0,0);
+            ASG_SAFE_CALL(asgObjectAddChild(new_trans_rot,surf_green));
+            ASG_SAFE_CALL(asgObjectAddChild(new_trans,new_trans_rot));
+            ASG_SAFE_CALL(asgObjectAddChild(root,new_trans));
+           // ASG_SAFE_CALL(asgObjectAddChild(trans,object2));
+          //  ASG_SAFE_CALL(asgObjectAddChild(root,object2));
+
+
+
+            ASG_SAFE_CALL(asgBuildANARIWorld(root,device,world,
+                                         ASG_BUILD_WORLD_FLAG_FULL_REBUILD,0));
+
+            anariCommit(device,world);
+        }
+        ASGTransform makeTransform(int axis, float angle, float tx, float ty, float tz)
+        {
+            float cosa = cosf(angle);
+            float sina = sinf(angle);
+
+            if (axis == 0) {
+                float R[] = {1.f,0.f,0.f,
+                             0.f,cosa,sina,
+                             0.f,-sina,cosa,
+                             tx,ty,tz};
+                return asgNewTransform(R);
+            } else if (axis == 1) {
+                float R[] = {cosa,0.f,sina,
+                             0.f,1.f,0.f,
+                             -sina,0.f,cosa,
+                             tx,ty,tz};
+                return asgNewTransform(R);
+            } else { assert(axis == 2);
+                float R[] = {cosa,sina,0.f,
+                             -sina,cosa,0.f,
+                             0.f,0.f,1.f,
+                             tx,ty,tz};
+                return asgNewTransform(R);
+            }
+        }
+    ASGTransform makeRotation(int axis, float angle)
+    {
+        float cosa = cosf(angle);
+        float sina = sinf(angle);
+
+        if (axis == 0) {
+            float R[] = {1.f,0.f,0.f,
+                         0.f,cosa,sina,
+                         0.f,-sina,cosa,
+                         0.f,0.f,0.f};
+            return asgNewTransform(R);
+        } else if (axis == 1) {
+            float R[] = {cosa,0.f,sina,
+                         0.f,1.f,0.f,
+                         -sina,0.f,cosa,
+                         0.f,0.f,0.f};
+            return asgNewTransform(R);
+        } else { assert(axis == 2);
+            float R[] = {cosa,sina,0.f,
+                         -sina,cosa,0.f,
+                         0.f,0.f,1.f,
+                         0.f,0.f,0.f};
+            return asgNewTransform(R);
+        }
+    }
+        visionaray::aabb getBounds()
+        {
+            visionaray::aabb bbox;
+            bbox.invalidate();
+            ASG_SAFE_CALL(asgComputeBounds(root,&bbox.min.x,&bbox.min.y,&bbox.min.z,
+                                            &bbox.max.x,&bbox.max.y,&bbox.max.z,0));
+            return bbox;
+        }
+};
+
 
 // Load volume file or generate default volume
 struct VolumeScene : Scene

--- a/scenes/grabber.h
+++ b/scenes/grabber.h
@@ -294,7 +294,7 @@ struct Gameboard
 
     // the edge length of one gameboard square
     constexpr static float s_squareWidth = 1.f;
-    // the height of one gameboard square 
+    // the height of one gameboard square
     constexpr static float s_squareHeight = .1f;
     // the radius of one piece
     constexpr static float s_pieceRadius = .35f;
@@ -368,6 +368,7 @@ struct Grabber
                      0.f, 1.f, 0.f, 0.f,
                      0.f, 0.f, 1.f, 0.f,
                      0.f, 0.f, 0.f, 1.f};
+
         asg::TriangleGeometry faceset = asg::newTriangleGeometry(
             (float *)vals, NULL, NULL, 12, ind, sizeof(ind) / sizeof(ind[0]) / 3, NULL);
         asg::Material dfltColor = asg::newMaterial("matte");
@@ -427,7 +428,7 @@ struct Grabber
         trans = grabber::makeTransform(0, 0, 0.f, s_underArmLength / 2 + s_wristRadius, 0.0f);
 
         asg::SphereGeometry wrist = grabber::makeSphere(s_wristRadius * 1.5f);
-        // asg::CylinderGeometry wrist = grabber::makeCylinder(1.f,s_wristRadius * 1.5f);
+
         rot->addChild(asg::newSurface(wrist, dfltColor));
         trans->addChild(rot);
         from_wrist->addChild(trans);
@@ -437,7 +438,7 @@ struct Grabber
 
         // the part of the grabber starting with its hand to its finger
         asg::Object from_hand = asg::newObject();
-        // rotation and translation are different to Soluition
+
         rot = grabber::makeRotation(2, M_PI / 2);
         trans = grabber::makeTransform(0, 0, 0.0, s_wristRadius + hand_length / 2.f, 0);
         // TODO: Cone Geometry
@@ -455,11 +456,11 @@ struct Grabber
         asg::CylinderGeometry finger = grabber::makeCylinder(s_fingerLength, s_fingerRadius);
 
         trans = grabber::makeTransform(0, 0, 0.0, hand_length / 2 + s_fingerLength / 2, 0.0);
-        trans->addChild(asg::newSurface(finger, dfltColor));
-        from_finger->addChild(trans);
-        trans = grabber::makeTransform(0, 0, 0.0, s_fingerLength / 2 + Gameboard::s_pieceHeight / 2, 0.0);
 
-        from_finger->getChild(0)->addChild(trans);
+        trans->addChild(asg::newSurface(finger, dfltColor));
+
+
+        from_finger->addChild(trans);
         from_hand->getChild(0)->getChild(0)->addChild(from_finger);
         m_finger = from_finger;
 

--- a/scenes/grabber.h
+++ b/scenes/grabber.h
@@ -40,6 +40,17 @@ namespace grabber
         return cyl;
     }
 
+    asg::SphereGeometry makeSphere(float radius)
+    {
+        float* sphVertex = new float[3] { 0,0,0};
+        float* sphRadius = new float[1] { radius };
+
+        asg::SphereGeometry sph = asg::newSphereGeometry(
+                sphVertex,sphRadius,nullptr,1,nullptr,0);
+
+        return sph;
+    }
+
     asg::Transform makeRotation(int axis, float angle)
     {
         float cosa = cosf(angle);

--- a/scenes/grabber.h
+++ b/scenes/grabber.h
@@ -420,6 +420,51 @@ struct Grabber
         from_elbow->getChild(0)->addChild(from_under_arm);
 
         m_from_under_arm = from_under_arm;
+
+        // the part of the grabber starting with its wrist to its finger
+        asg::Object from_wrist = asg::newObject();
+        rot = grabber::makeRotation(0, M_PI / 2);
+        trans = grabber::makeTransform(0, 0, 0.f, s_underArmLength / 2 + s_wristRadius, 0.0f);
+
+        asg::SphereGeometry wrist = grabber::makeSphere(s_wristRadius * 1.5f);
+        // asg::CylinderGeometry wrist = grabber::makeCylinder(1.f,s_wristRadius * 1.5f);
+        rot->addChild(asg::newSurface(wrist, dfltColor));
+        trans->addChild(rot);
+        from_wrist->addChild(trans);
+        // m_azimuth->addChild(from_under_arm);
+        // from_wrist->addChild(m_azimuth);
+        from_under_arm->getChild(0)->addChild(from_wrist);
+
+        // the part of the grabber starting with its hand to its finger
+        asg::Object from_hand = asg::newObject();
+        // rotation and translation are different to Soluition
+        rot = grabber::makeRotation(2, M_PI / 2);
+        trans = grabber::makeTransform(0, 0, 0.0, s_wristRadius + hand_length / 2.f, 0);
+        // TODO: Cone Geometry
+
+        asg::CylinderGeometry hand = grabber::makeCylinder(hand_length, s_handRadius);
+
+        trans->addChild(asg::newSurface(hand, dfltColor));
+        rot->addChild(trans);
+        from_hand->addChild(rot);
+        from_wrist->getChild(0)->getChild(0)->addChild(from_hand);
+
+        // the finger of the grabber
+        asg::Object from_finger = asg::newObject();
+
+        asg::CylinderGeometry finger = grabber::makeCylinder(s_fingerLength, s_fingerRadius);
+
+        trans = grabber::makeTransform(0, 0, 0.0, hand_length / 2 + s_fingerLength / 2, 0.0);
+        trans->addChild(asg::newSurface(finger, dfltColor));
+        from_finger->addChild(trans);
+        trans = grabber::makeTransform(0, 0, 0.0, s_fingerLength / 2 + Gameboard::s_pieceHeight / 2, 0.0);
+
+        from_finger->getChild(0)->addChild(trans);
+        from_hand->getChild(0)->getChild(0)->addChild(from_finger);
+        m_finger = from_finger;
+
+        printSceneGraph((ASGObject)*grabber, true);
+        m_sceneGraph = grabber;
     }
 
     void attachGameboard(Gameboard *gameboard)

--- a/scenes/island.h
+++ b/scenes/island.h
@@ -1,0 +1,503 @@
+#pragma once
+
+#include <asg/asg.hpp>
+#include "../scenes.h"
+#include <visionaray/math/vector.h>
+
+namespace island
+{ 
+    asg::CylinderGeometry makeCylinder(float height, float radius)
+    {
+        float* cylVertex = new float[6] { 0.f,-height/2.f,0.f,
+                                          0.f,height/2.f,0.f };
+        float* cylRadius = new float[1] { radius };
+        uint8_t* cylCap = new uint8_t[1] { 1 };
+        asg::CylinderGeometry cyl = asg::newCylinderGeometry(
+                cylVertex,cylRadius,nullptr,cylCap,2,nullptr,0);
+
+        return cyl;
+    }
+
+    asg::Transform makeTransform(int axis, float angle, float tx, float ty, float tz)
+    {
+        float cosa = cosf(angle);
+        float sina = sinf(angle);
+
+        if (axis == 0) {
+            float R[] = {1.f,0.f,0.f,
+                         0.f,cosa,sina,
+                         0.f,-sina,cosa,
+                         tx,ty,tz};
+            return asg::newTransform(R);
+        } else if (axis == 1) {
+            float R[] = {cosa,0.f,sina,
+                         0.f,1.f,0.f,
+                         -sina,0.f,cosa,
+                         tx,ty,tz};
+            return asg::newTransform(R);
+        } else { assert(axis == 2);
+            float R[] = {cosa,sina,0.f,
+                         -sina,cosa,0.f,
+                         0.f,0.f,1.f,
+                         tx,ty,tz};
+            return asg::newTransform(R);
+        }
+    }
+    asg::TriangleGeometry makeCube(float width, float height, float depth)
+    {
+        float w2 = width*.5f;
+        float h2 = height*.5f;
+        float d2 = depth*.5f;
+        float* cubeVertex = new float[24] {-w2,-h2,-d2,
+                                            w2,-h2,-d2,
+                                            w2, h2,-d2,
+                                           -w2, h2,-d2,
+                                            w2,-h2, d2,
+                                           -w2,-h2, d2,
+                                           -w2, h2, d2,
+                                            w2, h2, d2};
+
+        uint32_t* cubeIndex = new uint32_t[36] {0,1,2, 0,2,3, 4,5,6, 4,6,7,
+                                                1,4,7, 1,7,2, 5,0,3, 5,3,6,
+                                                5,4,1, 5,1,0, 3,2,7, 3,7,6};
+        asg::TriangleGeometry cube = asg::newTriangleGeometry(
+                cubeVertex,NULL,NULL,8,cubeIndex,12,NULL,NULL,NULL,NULL);
+
+        return cube;
+    }
+}
+struct Sky
+{
+     asg::Object m_sceneGraph = nullptr;
+};
+struct Ship
+{
+    Ship(){
+        initSceneGraph();
+    }
+  
+    void initSceneGraph()
+    {
+        if (m_sceneGraph != NULL) // this should never happen!
+            m_sceneGraph->release();
+
+        // start with root node of scene graph
+        m_sceneGraph = asg::newObject();
+        auto obj = asg::newObject();
+        asg::Transform obj_trans = island::makeTransform(1, -1.5708f,0,0.25 + -1.04308 * pow(10,-7),0);
+        obj->addChild(obj_trans);
+        m_sceneGraph->addChild(obj);
+
+        // the shape of one square
+        
+        //indexed face set
+       
+        float* points = new float[105] {3, 1, -1,
+			            1.5, 1, -1.25,
+			            0, 1, -1.5,
+			            -1.5, 1, -1.25,
+			            -2.5, 1, -0.75,
+			            -3, 1, 0,
+			            -2.5, 1, 0.75,
+			            -1.5, 1, 1.25,
+			            0, 1, 1.5,
+			            1.5, 1, 1.25,
+			            3, 1, 1,
+			            2.75, 0.5, -0.75,
+			            1.5, 0.5, -1,
+			            0.25, 0.5, -1.25,
+			            -1.5, 0.5, -1,
+			            -2, 0.5, -0.5,
+			            -2.25, 0.5, 0,
+			            -2, 0.5, 0.5,
+			            -1.5, 0.5, 1,
+			            0.25, 0.5, 1.25,
+			            1.5, 0.5, 1,
+			            2.75, 0.5, 0.75,
+			            2.5, 0, -0.5,
+			            1.25, 0, -0.75,
+			            0.25, 0, -0.75,
+			            -0.75, 0, -0.5,
+			            -1.25, 0, 0,
+			            -0.75, 0, 0.5,
+			            0.25, 0, 0.75,
+			            1.25, 0, 0.75,
+			            2.5, 0, 0.5,
+			            2.25, -0.25, 0,
+			            1.25, -0.5, 0,
+			            0.25, -0.5, 0,
+			            -0.5, -0.25, 0 };
+
+         uint32_t* index = new uint32_t[60] { 0, 11, 1, 
+                                              1, 11, 12,
+			                                  1, 12, 2,
+                                              2, 12, 13,
+			                                  2, 13, 3,
+                                              3, 13, 14,
+                                              3, 14, 4, 
+                                              4, 14, 15,
+			                                  4, 15, 5,
+                                              5, 15, 16,
+			                                  5, 16, 17,
+                                              5, 17, 6,
+			                                  6, 17, 18,
+                                              6, 18, 7,
+			                                  7, 18, 19,
+                                              7, 19, 8,
+			                                  8, 19, 20, 
+                                              8, 20, 9,
+			                                  9, 20, 21,
+                                              9, 21, 10 };
+
+        asg::TriangleGeometry ind_face_set1 = asg::newTriangleGeometry(
+                points,NULL,NULL,35,index,20,NULL,NULL,NULL,NULL);
+        asg::Material ind_face_set1_mat = asg::newMaterial("matte");
+               ind_face_set1_mat->setParam(asg::Param("kd",0.8f, 0.713178f, 0.76912f));
+        asg::Transform trans_ind_face_set1 = island::makeTransform(0,0.f,0, 0.75, 0.0);
+        trans_ind_face_set1->addChild(asg::newSurface(ind_face_set1, ind_face_set1_mat));
+        obj->addChild(trans_ind_face_set1);
+
+          uint32_t* index2 = new uint32_t[54] { 11, 22, 12, 12, 22, 23,
+			                                    12, 23, 13, 13, 23, 24,
+			                                    13, 24, 14, 14, 24, 25,
+			                                    14, 25, 15, 15, 25, 26,
+			                                    15, 26, 16, 16, 26, 17,
+			                                    17, 26, 27, 17, 27, 18,
+			                                    18, 27, 28, 18, 28, 19,
+			                                    19, 28, 29, 19, 29, 20,
+			                                    20, 29, 30, 20, 30, 21 } ; 
+
+        asg::TriangleGeometry ind_face_set2 = asg::newTriangleGeometry(
+                points,NULL,NULL,35,index2,18,NULL,NULL,NULL,NULL);
+        asg::Material ind_face_set2_mat = asg::newMaterial("matte");
+        ind_face_set2_mat->setParam(asg::Param("kd",0.425949f, 0.528619f, 0.8f));
+        asg::Transform trans_ind_face_set2 = island::makeTransform(0,0.f,0.25, 0.25, -2.98023/ pow(10,8));
+        trans_ind_face_set2->addChild(asg::newSurface(ind_face_set2, ind_face_set2_mat));
+        obj->addChild(trans_ind_face_set2);
+
+
+        uint32_t* index3 = new uint32_t[42] { 22, 31, 23,
+                                              23, 31, 32,
+			                                  23, 32, 24,
+                                              24, 32, 33,
+			                                  24, 33, 25,
+                                              25, 33, 34,
+			                                  25, 34, 26,
+                                              26, 34, 27,
+			                                  27, 34, 33, 
+                                              27, 33, 28,
+			                                  28, 33, 32,
+                                              28, 32, 29,
+			                                  29, 32, 31,
+                                              29, 31, 30 
+                                            };
+        
+        asg::TriangleGeometry ind_face_set3 = asg::newTriangleGeometry(
+                points,NULL,NULL,35,index3,14,NULL,NULL,NULL,NULL);
+        asg::Material ind_face_set3_mat = asg::newMaterial("matte");
+        ind_face_set3_mat->setParam(asg::Param("kd",0.723297f, 0.742473f, 0.8f));
+        obj->addChild(asg::newSurface(ind_face_set3, ind_face_set3_mat));
+
+          uint32_t* index4 = new uint32_t[15] { 0, 10, 11, 
+                                                11, 10, 21,
+			                                    11, 21, 22, 
+                                                22, 21, 30,
+			                                    22, 30, 31
+                                            };
+        
+        asg::TriangleGeometry ind_face_set4 = asg::newTriangleGeometry(
+                points,NULL,NULL,35,index4,5,NULL,NULL,NULL,NULL);
+        asg::Material ind_face_set4_mat = asg::newMaterial("matte");
+        obj->addChild(asg::newSurface(ind_face_set4, ind_face_set4_mat));
+
+
+        uint32_t* index5 = new uint32_t[27] { 0, 1, 10,
+                                              1, 9, 10,
+			                                  1, 2, 9,
+                                              2, 8, 9,
+			                                  2, 3, 8,
+                                              3, 7, 8,
+			                                  3, 4, 7,
+                                              4, 6, 7,
+			                                  4, 5, 6}; 
+            
+        asg::TriangleGeometry ind_face_set5 = asg::newTriangleGeometry(
+                points,NULL,NULL,35,index5,9,NULL,NULL,NULL,NULL);
+        asg::Material ind_face_set5_mat = asg::newMaterial("matte");
+        obj->addChild(asg::newSurface(ind_face_set5, ind_face_set5_mat));
+
+
+        asg::Object cube = asg::newObject();
+        asg::TriangleGeometry cube_geom = island::makeCube(1, 1,1);
+        asg::Material cube_mat = asg::newMaterial("matte");
+         cube_mat->setParam(asg::Param("kd",0.8f, 0.133383f, 0.185233f));
+        asg::Transform transcube = island::makeTransform(0,0.f,0.342307, 0.933647, 0.0146482);
+        transcube->addChild(asg::newSurface(cube_geom,cube_mat));
+        obj->addChild(transcube);
+
+
+        asg::Object cyl1 = asg::newObject();
+        asg::CylinderGeometry cyl_geom1 = island::makeCylinder(2, 0.2f);
+        asg::Material cyl_mat1 = asg::newMaterial("matte");
+        cyl_mat1->setParam(asg::Param("kd",0.454304f, 0.522407f, 0.8f));
+        asg::Transform trans1 = island::makeTransform(0,0.f,-0.7f, 1.5f, 0);
+        trans1->addChild(asg::newSurface(cyl_geom1,cyl_mat1));
+        obj->addChild(trans1);
+
+        
+        asg::Object cyl2 = asg::newObject();
+        asg::CylinderGeometry cyl_geom2 = island::makeCylinder(2, 0.2f);
+        asg::Material cyl_mat2 = asg::newMaterial("matte");
+        asg::Transform trans2 = island::makeTransform(0,0,0,1.5,0);
+        trans2->addChild(asg::newSurface(cyl_geom2,cyl_mat2));
+        obj->addChild(trans2);
+
+
+        asg::Object cyl3 = asg::newObject();
+        asg::CylinderGeometry cyl_geom3 = island::makeCylinder(2, 0.2f);
+        asg::Material cyl_mat3 = asg::newMaterial("matte");
+        asg::Transform trans3 = island::makeTransform(0,0,0.7,1.5,0);
+        trans3->addChild(asg::newSurface(cyl_geom3,cyl_mat3));
+        obj->addChild(trans3);
+
+
+        asg::Object cyl4 = asg::newObject();
+        asg::CylinderGeometry cyl_geom4 = island::makeCylinder(2, 0.2f);
+        asg::Material cyl_mat4 = asg::newMaterial("matte");
+        asg::Transform trans4 = island::makeTransform(0,0,1.4,1.5,0);
+        trans4->addChild(asg::newSurface(cyl_geom4,cyl_mat4));
+        obj->addChild(trans4);
+
+        
+        // colors
+
+        asg::Material greenColor = asg::newMaterial("matte");
+        greenColor->setParam(asg::Param("kd",0.f,1.f,0.f));
+
+        asg::Material redColor = asg::newMaterial("matte");
+        redColor->setParam(asg::Param("kd",1.f,0.f,0.f));
+
+       
+    }
+    asg::Object m_sceneGraph = nullptr;
+};
+struct Island
+{
+    asg::Object m_sceneGraph = nullptr;
+    Island(){
+        initSceneGraph();
+    }
+    void initSceneGraph()
+    {
+        m_sceneGraph = asg::newObject();
+        auto obj = asg::newObject();
+        m_sceneGraph->addChild(obj);
+        asg::Object ground = asg::newObject();
+        asg::Transform ground_trans = island::makeTransform(0,0.f,0, -2.f, 0.0);
+        ground->addChild(ground_trans);
+        obj->addChild(ground);
+        //Surface
+
+        float* points = new float[210] {27.6391, -1.75557, -31.7062,
+				      -30.8926, -1.75558 ,-30.8222,
+				      -30.8926 ,-1.75564, 30.763,
+				      -0.060009 ,-0.79579, -9.09962,
+				      -1.45977, 2.05291, -4.67986,
+				      1.39347, 6.73367, -1.55778,
+				      -0.782147, 4.83622 ,-1.29684,
+				      -0.775763, 4.88207 ,1.01202,
+				      -0.850866, -0.014241, 5.83507,
+				      0.195148,-1.62194, 11.4319,
+				      31.3791 ,-1.75563 ,29.4807,
+				      -29.6103, -1.75558 ,-31.5087,
+				      -31.5791 ,-1.75558 ,-29.5399,
+				      -31.7244 ,-1.75558 ,-25.7478,
+				      -31.5791 ,-1.75564, 29.4807,
+				      13.5377, -1.67449, -3.09326,
+				      9.88464, -1.02293, -1.59336,
+				      6.71738, 0.428669 ,-2.94258,
+				      4.9882 ,2.40808 ,-2.09548,
+				      4.32984 ,0.958669 ,-4.10522,
+				      1.19158 ,6.82022, -2.72392,
+				      -0.403269 ,-1.16022 ,8.54765,
+				      -0.086815 ,1.44414, 3.97684,
+				      -4.69863, -0.883111 ,5.84248,
+				      -0.359063, 4.3193, -3.94846,
+				      31.1086 ,-1.75563, 30.1946,
+				      30.1242 ,-1.75563 ,31.179,
+				      30.1242 ,-1.75557, -31.2382,
+				      31.1086 ,-1.75557 ,-30.2538,
+				      8.65026 ,-1.56, 7.5159,
+				      -8.86154 ,-1.63307, -8.16872,
+				      -8.00656 ,-1.64386, 9.11234,
+				      3.48848, 2.37778, 2.38558,
+				      0.051859 ,-1.32694 ,-10.7094,
+				      2.57863, 4.03321 ,-4.01883,
+				      -5.9281 ,-0.25699 ,1.17408,
+				      -2.40146 ,0.668804 ,4.04841,
+				      4.70488 ,-1.53651, -11.6068,
+				      3.83393, 4.66891 ,-1.45455,
+				      0.226306 ,5.7347 ,-0.844334,
+				      28.5722, -1.75563, 31.5958,
+				      31.5254, -1.75557 ,-28.7018,
+				      -28.7722 ,-1.75564 ,31.5958,
+				      6.04388 ,-1.22726, 7.04125,
+				      9.21036 ,-1.0032 ,-4.04637,
+				      7.16227, 0.405077, -1.80648,
+				      5.3018, -0.265163, 4.57253,
+				      3.76122 ,3.86475, 1.58433,
+				      4.80156, 2.19551, 0.685778,
+				      3.30443 ,4.7467, 1.45998,
+				      1.12275 ,5.83811 ,0.611587,
+				      0.774506 ,0.806252 ,-6.9796,
+				      0.026434, -1.74649 ,-13.8902,
+				      -2.83608 ,0.214381, -5.9377,
+				      0.720275, 7.02623 ,-1.68385,
+				      -9.07951 ,-1.36281 ,1.31578,
+				      -11.0086, -1.62174 ,1.61912,
+				      -3.31646, 1.85285, -2.1656,
+				      -7.69019 ,-0.979046 ,-2.60775,
+				      -1.14155, 1.53432, 3.68085,
+				      -0.540742 ,4.4997, 1.97302,
+				      7.59332, -0.844461, 3.55232,
+				      6.58523, -0.264617, 2.96109,
+				      4.27657, -1.28339, -10.0978,
+				      2.1282 ,1.19615 ,-6.26808,
+				      2.65516 ,-0.258378 ,-7.89528,
+				      -5.21086 ,-0.807199, -6.25868,
+				      2.47902,6.51247 ,-0.498268,
+				      -3.00833, 2.08575 ,0.849215,
+				      1.93217 ,-0.378062 ,6.08267};
+
+         uint32_t* index = new uint32_t[369] { 27, 0, 41, 2, 42, 14,
+				  40, 14, 42, 45, 16, 44,
+				  48, 45, 18, 17, 45, 44,
+				  17, 18, 45, 38, 47, 48,
+				  32, 48, 47, 38, 49, 47,
+				  53, 3, 66, 53, 4, 51,
+				  53, 51, 3, 66, 3, 33,
+				  24, 51, 4, 5, 67, 20,
+				  67, 38, 20, 23, 35, 55,
+				  58, 55, 35, 57, 58, 35,
+				  60, 7, 68, 16, 62, 61,
+				  40, 15, 29, 16, 61, 29,
+				  29, 61, 43, 32, 46, 62,
+				  61, 46, 43, 43, 46, 69,
+				  61, 62, 46, 44, 15, 63,
+				  37, 63, 15, 44, 63, 65,
+				  65, 63, 3, 51, 65, 3,
+				  51, 64, 65, 19, 65, 64,
+				  66, 30, 58, 31, 21, 23,
+				  21, 8, 23, 8, 36, 23,
+				  40, 10, 41, 40, 41, 15,
+				  17, 65, 19, 17, 19, 18,
+				  37, 15, 41, 52, 11, 30,
+				  57, 24, 4, 20, 34, 64,
+				  6, 24, 57, 6, 54, 24,
+				  5, 54, 39, 11, 14, 56,
+				  31, 56, 14, 23, 36, 35,
+				  68, 36, 60, 35, 36, 68,
+				  68, 7, 57, 57, 7, 6,
+				  31, 14, 40, 32, 69, 46,
+				  22, 69, 32, 22, 32, 49,
+				  49, 50, 60, 14, 12, 13,
+				  15, 44, 16, 17, 44, 65,
+				  49, 38, 67, 20, 64, 51,
+				  38, 34, 20, 21, 9, 43,
+				  21, 69, 8, 21, 43, 69,
+				  60, 59, 22, 60, 22, 49,
+				  41, 0, 11, 45, 62, 16,
+				  48, 62, 45, 32, 62, 48,
+				  64, 18, 19, 57, 66, 58,
+				  31, 9, 21, 60, 36, 59,
+				  27, 41, 28, 38, 18, 34,
+				  38, 48, 18, 49, 67, 50,
+				  67, 5, 50, 7, 50, 39,
+				  50, 5, 39, 11, 1, 12,
+				  12, 14, 11, 11, 52, 41,
+				  41, 52, 37, 52, 33, 37,
+				  63, 33, 3, 63, 37, 33,
+				  57, 4, 53, 57, 53, 66,
+				  64, 34, 18, 51, 24, 20,
+				  5, 20, 54, 54, 20, 24,
+				  39, 54, 6, 6, 7, 39,
+				  56, 30, 11, 35, 68, 57,
+				  25, 10, 26, 26, 10, 40,
+				  9, 31, 40, 8, 69, 22,
+				  8, 22, 36, 22, 59, 36,
+				  49, 32, 47, 50, 7, 60,
+				  43, 9, 29, 29, 15, 16,
+				  66, 33, 30, 30, 33, 52,
+				  31, 55, 56, 23, 55, 31,
+				  29, 9, 40, 30, 56, 55,
+				  58, 30, 55  };
+
+        asg::TriangleGeometry ind_sand = asg::newTriangleGeometry(
+        points,NULL,NULL,70,index,123,NULL,NULL,NULL,NULL);
+        asg::Material sand_mat = asg::newMaterial("matte");
+        sand_mat->setParam(asg::Param("kd",0.8f, 0.631111f, 0.340331f));
+      
+        ground->addChild(asg::newSurface(ind_sand, sand_mat));
+        //palm
+//    SoInput palmInput;
+//    if(!palmInput.openFile(Scene::getPathName("vegetation.iv")))
+//    {
+// 	   std::cerr << "failed to read surface.iv" << std::endl;
+// 	   return;
+//    }
+//    SoSeparator *palmSep = SoDB::readAll(&palmInput);
+//    palmInput.closeFile();
+//    setPart("vegetation", palmSep);
+
+    }
+
+ 
+};
+struct IslandScene: Scene
+{
+    IslandScene(ANARIDevice dev, ANARIWorld wrld)
+        : Scene(dev,wrld)
+    {
+        asg::Object scene = asg::newObject();
+
+       // scene->addChild(sky.m_sceneGraph);
+        scene->addChild(ship.m_sceneGraph);
+        scene->addChild(island.m_sceneGraph);
+        root = (ASGObject)*scene;
+
+        // Build up ANARI world
+        ASG_SAFE_CALL(asgBuildANARIWorld(root,device,world,
+                                         ASG_BUILD_WORLD_FLAG_FULL_REBUILD,0));
+
+        // Compute bounding box
+        ASG_SAFE_CALL(asgComputeBounds(root,&bbox.min.x,&bbox.min.y,&bbox.min.z,
+                                       &bbox.max.x,&bbox.max.y,&bbox.max.z,0));
+    }
+    virtual void beforeRenderFrame()
+    {
+        if (rebuildANARIWorld) {
+            ASG_SAFE_CALL(asgBuildANARIWorld(root,device,world,
+                        ASG_BUILD_WORLD_FLAG_FULL_REBUILD & ~ASG_BUILD_WORLD_FLAG_LIGHTS,0));
+
+            anariCommit(device,world);
+        }
+
+        rebuildANARIWorld = false;
+    }
+    bool needFrameReset()
+    {
+        return rebuildANARIWorld;
+    }
+    bool rebuildANARIWorld = false;
+
+    virtual visionaray::aabb getBounds()
+    {
+        return bbox;
+    }
+
+    visionaray::aabb bbox;
+
+    Island island;
+    Ship ship;
+    Sky sky;
+};

--- a/util.h
+++ b/util.h
@@ -109,6 +109,8 @@ static void printSceneGraph(ASGObject rootObj, bool verbose = false)
                                   << vertexColors << ' ' << indices;
                     } else if (type==ASG_TYPE_CYLINDER_GEOMETRY) {
                         std::cout << ", cylinder-geom";
+                    } else if (type==ASG_TYPE_SPHERE_GEOMETRY) {
+                        std::cout << ", sphere-geom";
                     }
 
                     ASGMaterial mat;

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -279,6 +279,8 @@ struct Viewer : visionaray::viewer_glut
                 scene = new SphereTest(device,world);
             else if (fileName=="select-test")
                 scene = new SelectTest(device,world);
+            else if (fileName=="transform-test")
+                scene = new TransformTest(device,world);
             else if (fileName=="grabber")
                 scene = new GrabberGame(device,world);
             else if (getExt(fileName)==".raw" || getExt(fileName)==".xvf" || getExt(fileName)==".rvf")

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -16,6 +16,7 @@
 #include <anari/anari_cpp.hpp>
 #include <imgui.h>
 #include "scenes/grabber.h"
+#include "scenes/island.h"
 #include "scenes.h"
 #include "util.h"
 
@@ -244,7 +245,10 @@ struct Viewer : visionaray::viewer_glut
             resetANARIMainLight();
         }
         //if (!anari.scene->handleSpaceMouseMove(event))
-            viewer_glut::on_space_mouse_move(event);
+    }
+    void on_key_press(visionaray::key_event const& event){
+         if (!anari.scene->handleKeyPress(event))
+            viewer_glut::on_key_press(event);
     }
 
     struct {
@@ -283,6 +287,8 @@ struct Viewer : visionaray::viewer_glut
                 scene = new TransformTest(device,world);
             else if (fileName=="grabber")
                 scene = new GrabberGame(device,world);
+            else if (fileName=="island")
+                scene = new IslandScene(device,world);
             else if (getExt(fileName)==".raw" || getExt(fileName)==".xvf" || getExt(fileName)==".rvf")
                 scene = new VolumeScene(device,world,fileName.c_str());
             else


### PR DESCRIPTION
All the changes are listed below:

- add changes to the generic device's backend to being able to render sphere geometries
- expand CPP API by GetChildren Method, SphereGeometry methods, Set/Get visibility methods
- add the * operator for 4x4 Matrices
- Add the island scene (WIP)
- expand GrabberGame by logic which enables to select a piece by the keyboard and a red selector circle
- extend the structure of the grabber arm. In order for this to work as in OpenInventor the Application of transformations and rotations had to be changed in order to make roations possible from the local model coordinate system
- 